### PR TITLE
Correct broken link to flycheck-elixir-credo layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ configuration method.  You can register the package by calling:
 
 If you are using spacemacs, you can find a [contrib layer for using
 flycheck-elixir-credo
-[here](https://github.com/obmarg/dotfiles/tree/master/spacemacs.d/elixir-credo)
+[here](https://github.com/smeevil/flycheck-elixir-credo/blob/master/packages.el)


### PR DESCRIPTION
The link currently goes to a missing file on obmarg/elixir-dogma repo, but I believe it was intended to point to the `packages.el` in current repo