### PR TITLE
Fix missing credo reports

### DIFF
--- a/flycheck-elixir-credo.el
+++ b/flycheck-elixir-credo.el
@@ -42,7 +42,7 @@
 
 (flycheck-define-checker elixir-credo
   "Defines a checker for elixir with credo"
-  :command ("mix" "credo" "--format" "flycheck" "--stdin" source-original)
+  :command ("mix" "credo" "--format" "flycheck" source-inplace)
   :standard-input t
   :error-patterns
   (


### PR DESCRIPTION
Credo reports were not showing up for me in spacemacs' flycheck error list. the `flycheck-elixir-dogma` package uses `source-inplace` instead of the stdin approach here, and when I used that the reports show up in the error list as expected.